### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ imfs = ["spin"]
 dfs = ["std"]
 
 [dependencies]
-spin = { version = "0.9", optional = true }
+spin = { version = "0.9.8", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)